### PR TITLE
ci: fix duplicate workflow runs and gate Docker by tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,13 @@ name: CI
 
 on:
   push:
+    branches: [master]
+    tags: ['v*']
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
 


### PR DESCRIPTION
## Summary
- Restrict push trigger to default branch + tags
- Add concurrency group to cancel superseded runs

## Test plan
- [ ] Verify PRs trigger CI once (not twice)
- [ ] Verify Docker push only happens on tag push